### PR TITLE
add valid license expression to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,7 @@
   "version": "1.0.1",
   "description": "Micro subset of unicode data files for markdown-it projects.",
   "repository": "markdown-it/uc.micro",
-  "license": {
-    "type": "WTFPL",
-    "url": "http://www.wtfpl.net/txt/copying/"
-  },
+  "license": "WTFPL",
   "files": [
     "categories/",
     "properties/",


### PR DESCRIPTION
As documented on the NPM documentation (https://docs.npmjs.com/files/package.json#license). The license field has to comply with the SPDX specification for communicating the licenses and copyrights associated with a software package. This commit changes the license to a valid SPDX value (WTFPL)
